### PR TITLE
feat: add support for inline tab renaming

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,5 +1,4 @@
-import { Fragment } from "react";
-import { PlusIcon, XIcon } from "lucide-react";
+import { PlusIcon, } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -9,10 +8,11 @@ import {
 import { useMonacoEditor } from "~/hooks/use-monaco-editor";
 import { useTabs } from "~/hooks/use-tab";
 import { useTabsStore } from "~/store/tabs";
+import { Tab } from "./tab";
 
 export function Header() {
   const { isLoading } = useMonacoEditor();
-  const { tabs, activeTab, createNewTab, deleteTab, setActiveTab } = useTabs()
+  const { tabs, createNewTab, } = useTabs()
 
   const hasHydratedStorage = useTabsStore(state => state._hasHydrated);
 
@@ -25,35 +25,7 @@ export function Header() {
     >
       {hasHydratedStorage ?
         tabs?.map(tab => (
-          <Fragment key={tab.id}>
-            {tab.id === activeTab.id ? (
-              <div className="flex items-center justify-between text-white bg-[var(--border-color)] pl-4 pr-1 w-40 rounded-t-lg ml-[3px] mt-auto h-[calc(100%-2px)] border-x border-t border-neutral-700">
-                <span className="text-sm font-semibold truncate">
-                  {tab.name}
-                </span>
-                {tabs.length > 1 && (
-                  <button
-                    className="ml-0.5 hover:bg-neutral-500/10 p-[3px] rounded-md border border-transparent hover:border-neutral-700"
-                    aria-label="Delete tab"
-                    onClick={() => deleteTab(tab.id)}
-                  >
-                    <XIcon className="size-3.5" />
-                  </button>
-                )}
-              </div>
-            ) : (
-              <button
-                disabled={isLoading}
-                onClick={() => setActiveTab(tab)}
-                aria-label="Switch tab"
-                className="flex items-center justify-between text-white bg-[var(--border-color)] opacity-50 h-[calc(100%-3px)] px-4 w-40 rounded-t-lg mt-auto ml-[3px] hover:opacity-100 border-x border-t border-transparent hover:border-neutral-700 transition-all disabled:cursor-not-allowed"
-              >
-                <span className="text-sm truncate">
-                  {tab.name}
-                </span>
-              </button>
-            )}
-          </Fragment>
+          <Tab key={tab.id} tab={tab} />
         )) : (
           <div className="flex items-center justify-between text-white opacity-50 bg-[#282A36] h-full pl-4 pr-1 w-40 rounded-t-lg mt-0.5 ml-0.5 border-x border-t border-neutral-700">
             <span className="text-sm">

--- a/app/components/tab.tsx
+++ b/app/components/tab.tsx
@@ -1,0 +1,46 @@
+import { Fragment } from "react";
+import { XIcon } from "lucide-react";
+import { useMonacoEditor } from "~/hooks/use-monaco-editor";
+import { useTabs } from "~/hooks/use-tab";
+import type { Tab } from "~/lib/types";
+
+interface TabProps {
+  tab: Tab;
+}
+
+export function Tab({ tab }: TabProps) {
+  const { isLoading } = useMonacoEditor();
+  const { tabs, activeTab, deleteTab, setActiveTab } = useTabs()
+
+  return (
+    <Fragment>
+      {tab.id === activeTab.id ? (
+        <div className="flex items-center justify-between text-white bg-[var(--border-color)] pl-4 pr-1 w-40 rounded-t-lg ml-[3px] mt-auto h-[calc(100%-2px)] border-x border-t border-neutral-700">
+          <span className="text-sm font-semibold truncate">
+            {tab.name}
+          </span>
+          {tabs.length > 1 && (
+            <button
+              className="ml-0.5 hover:bg-neutral-500/10 p-[3px] rounded-md border border-transparent hover:border-neutral-700"
+              aria-label="Delete tab"
+              onClick={() => deleteTab(tab.id)}
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          )}
+        </div>
+      ) : (
+        <button
+          disabled={isLoading}
+          onClick={() => setActiveTab(tab)}
+          aria-label="Switch tab"
+          className="flex items-center justify-between text-white bg-[var(--border-color)] opacity-50 h-[calc(100%-3px)] px-4 w-40 rounded-t-lg mt-auto ml-[3px] hover:opacity-100 border-x border-t border-transparent hover:border-neutral-700 transition-all disabled:cursor-not-allowed"
+        >
+          <span className="text-sm truncate">
+            {tab.name}
+          </span>
+        </button>
+      )}
+    </Fragment>
+  )
+}

--- a/app/components/tab.tsx
+++ b/app/components/tab.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { XIcon } from "lucide-react";
 import { useMonacoEditor } from "~/hooks/use-monaco-editor";
-import { useTabs } from "~/hooks/use-tab";
+import { useTabEditing, useTabs } from "~/hooks/use-tab";
 import type { Tab } from "~/lib/types";
 
 interface TabProps {
@@ -11,14 +11,33 @@ interface TabProps {
 export function Tab({ tab }: TabProps) {
   const { isLoading } = useMonacoEditor();
   const { tabs, activeTab, deleteTab, setActiveTab } = useTabs()
+  const { handleEdit, handleRename, inputRef, isEditing, setTabName, tabName } = useTabEditing(tab);
 
   return (
     <Fragment>
       {tab.id === activeTab.id ? (
         <div className="flex items-center justify-between text-white bg-[var(--border-color)] pl-4 pr-1 w-40 rounded-t-lg ml-[3px] mt-auto h-[calc(100%-2px)] border-x border-t border-neutral-700">
-          <span className="text-sm font-semibold truncate">
-            {tab.name}
-          </span>
+          {
+            isEditing ? (
+              <div className="relative w-full bg-white/10 after:bg-blue-400 after:absolute after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-center after:transform after:scale-x-0 after:transition-transform after:duration-150 focus-within:after:scale-x-100">
+                <input
+                  ref={inputRef}
+                  value={tabName}
+                  onChange={(e) => setTabName(e.target.value)}
+                  onBlur={handleRename}
+                  onKeyDown={(e) => e.key === "Enter" && handleRename()}
+                  className="text-sm bg-transparent outline-none text-center w-full"
+                />
+              </div>
+            ) : (
+              <button
+                onClick={handleEdit}
+                className="text-sm truncate w-full"
+              >
+                {tab.name}
+              </button>
+            )
+          }
           {tabs.length > 1 && (
             <button
               className="ml-0.5 hover:bg-neutral-500/10 p-[3px] rounded-md border border-transparent hover:border-neutral-700"

--- a/app/hooks/use-tab.tsx
+++ b/app/hooks/use-tab.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from "react";
 import { useTabsStore } from "~/store/tabs"
+import type { Tab } from "~/lib/types";
 
 export function useTabs() {
   const tabs = useTabsStore(state => state.tabs);
@@ -7,6 +9,7 @@ export function useTabs() {
   const setActiveTab = useTabsStore(state => state.setActiveTab);
   const createNewTab = useTabsStore(state => state.createNewTab);
   const deleteTab = useTabsStore(state => state.deleteTab);
+  const updateTab = useTabsStore(state => state.updateTab);
 
   return {
     tabs,
@@ -15,5 +18,45 @@ export function useTabs() {
     setActiveTab,
     createNewTab,
     deleteTab,
+    updateTab
   }
+}
+
+export function useTabEditing(tab: Tab) {
+  const {updateTab} = useTabs();
+  const [isEditing, setIsEditing] = useState(false);
+  const [tabName, setTabName] = useState(tab.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleRename = () => {
+    setIsEditing(false);
+    updateTab(tab.id, {
+      name: tabName.trim() || "Untitled Tab",
+    });
+  };
+
+  const handleEdit = () => {
+    setIsEditing(true);
+    setTabName(tab.name);
+  };
+
+  useEffect(() => {
+    setTabName(tab.name);
+  }, [tab.name]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.setSelectionRange(0, tab.name.length);
+    }
+  }, [isEditing, tab.name]);
+
+  return {
+    isEditing,
+    tabName,
+    setTabName,
+    inputRef,
+    handleRename,
+    handleEdit,
+  };
 }

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -5,6 +5,7 @@ export interface Tab {
   name: string;
   code: string;
   createdAt: Date;
+  hasRealName?: boolean;
 }
 
 export type SettingsTab = 'general' | 'appearance' | 'formatting' | 'support' | 'resources' | 'ai';

--- a/app/store/tabs.ts
+++ b/app/store/tabs.ts
@@ -10,6 +10,7 @@ interface TabsState {
   setActiveTab: (tab: Tab) => void;
   setCode: (code: Tab['code']) => void;
   deleteTab: (id: Tab['id']) => void;
+  updateTab: (id: Tab['id'], tab: Partial<Omit<Tab, 'id'>>) => void;
 }
 
 const DEFAULT_TAB: Tab = {
@@ -32,7 +33,7 @@ export const useTabsStore = create<TabsState>()(persist((set) => ({
       if (tab.id === activeTab.id) {
         return {
           ...tab,
-          name: code.trim() ? `${code.trim().slice(0, 20)}...` : tab.name,
+          name: !tab.hasRealName && code.trim() ? `${code.trim().slice(0, 20)}...` : tab.name,
           code,
         };
       }
@@ -72,6 +73,24 @@ export const useTabsStore = create<TabsState>()(persist((set) => ({
     return {
       tabs: updatedTabs,
       activeTab,
+    }
+  }),
+
+  updateTab: (id: Tab['id'], tab: Partial<Omit<Tab, 'id'>>) => set((state) => {
+    const { tabs } = state;
+
+    const index = tabs.findIndex(t => t.id === id);
+    const oldTab = tabs[index];
+    const updatedTab = { ...oldTab, ...tab, hasRealName: Boolean(oldTab.hasRealName || (oldTab.name !== tab.name)) };
+    const updatedTabs = [
+      ...tabs.slice(0, index),
+      updatedTab,
+      ...tabs.slice(index + 1),
+    ]
+
+    return {
+      tabs: updatedTabs,
+      activeTab: updatedTab,
     }
   })
 }),


### PR DESCRIPTION
### Summary
This Pull Request introduces functionality to rename tabs directly from the Tab component, improving the user experience by allowing seamless updates to tab names.

### Changes
- Implemented inline renaming in the `Tab` component with a user-friendly editing flow.
- Added `updateTab` to the store for persisting tab name changes.
- Enhanced UI with transitions and focus management for a smoother interaction.

### How it works
1. Click on a tab name to activate an input field for editing.
2. Press `Enter` or blur the input field to save changes.
3. Changes are persisted to the store and immediately reflected in the UI.

### Related Issue
Closes #4